### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "pimoroni_interstate75"
 version = "0.1.0"
 authors = ["Eric Seppanen"]
 edition = "2021"
-homepage = "https://github.com/ericseppanen/pimoroni-interstate75"
+repository = "https://github.com/ericseppanen/pimoroni-interstate75"
 description = "Board Support Package for the Pimoroni Interstate 75"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.